### PR TITLE
Fix: Improve error logging for null Query object in OneCAccessor

### DIFF
--- a/OneCSqlEtl/OneCAccessor.cs
+++ b/OneCSqlEtl/OneCAccessor.cs
@@ -186,7 +186,7 @@ namespace OneCSqlEtl
                 q = _v8Application.NewObject("Query");
                 if (q == null)
                 {
-                    _log.LogError("Не удалось создать объект Query для Контрагентов (_v8Application.NewObject вернул null).");
+                    _log.LogError("Не удалось создать объект Query для Контрагентов (_v8Application.NewObject(\"Query\") вернул null).");
                     yield break;
                 }
 
@@ -299,7 +299,7 @@ namespace OneCSqlEtl
             try
             {
                 q = _v8Application.NewObject("Query");
-                if (q == null) { _log.LogError("Не удалось создать объект Query для Номенклатуры."); yield break; }
+                if (q == null) { _log.LogError("Не удалось создать объект Query для Номенклатуры (_v8Application.NewObject(\"Query\") вернул null)."); yield break; }
                 try { q.Text = query; } catch (COMException ex) { _log.LogError(ex, "COMException текст запроса Номенклатуры."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка текст запроса Номенклатуры."); yield break; }
                 try { executionResult = q.Execute(); } catch (COMException ex) { _log.LogError(ex, "COMException запрос Номенклатуры."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка запрос Номенклатуры."); yield break; }
                 if (executionResult == null) { _log.LogWarning("Query.Execute null для Номенклатуры."); yield break; }
@@ -346,7 +346,7 @@ namespace OneCSqlEtl
             try
             {
                 q = _v8Application.NewObject("Query");
-                if (q == null) { _log.LogError("Не удалось создать объект Query для Договоров."); yield break; }
+                if (q == null) { _log.LogError("Не удалось создать объект Query для Договоров (_v8Application.NewObject(\"Query\") вернул null)."); yield break; }
                 try { q.Text = query; } catch (COMException ex) { _log.LogError(ex, "COMException текст запроса Договоров."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка текст запроса Договоров."); yield break; }
                 try { executionResult = q.Execute(); } catch (COMException ex) { _log.LogError(ex, "COMException запрос Договоров."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка запрос Договоров."); yield break; }
                 if (executionResult == null) { _log.LogWarning("Query.Execute null для Договоров."); yield break; }
@@ -392,7 +392,7 @@ namespace OneCSqlEtl
             try
             {
                 q = _v8Application.NewObject("Query");
-                if (q == null) { _log.LogError("Не удалось создать объект Query для Организаций."); yield break; }
+                if (q == null) { _log.LogError("Не удалось создать объект Query для Организаций (_v8Application.NewObject(\"Query\") вернул null)."); yield break; }
                 try { q.Text = query; } catch (COMException ex) { _log.LogError(ex, "COMException текст запроса Организаций."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка текст запроса Организаций."); yield break; }
                 try { executionResult = q.Execute(); } catch (COMException ex) { _log.LogError(ex, "COMException запрос Организаций."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка запрос Организаций."); yield break; }
                 if (executionResult == null) { _log.LogWarning("Query.Execute null для Организаций."); yield break; }
@@ -434,7 +434,7 @@ namespace OneCSqlEtl
             try
             {
                 q = _v8Application.NewObject("Query");
-                if (q == null) { _log.LogError("Не удалось создать объект Query для Строк Продаж."); yield break; }
+                if (q == null) { _log.LogError("Не удалось создать объект Query для Строк Продаж (_v8Application.NewObject(\"Query\") вернул null)."); yield break; }
                 try { q.Text = query; } catch (COMException ex) { _log.LogError(ex, "COMException текст запроса Строк Продаж."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка текст запроса Строк Продаж."); yield break; }
                 try { executionResult = q.Execute(); } catch (COMException ex) { _log.LogError(ex, "COMException запрос Строк Продаж."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка запрос Строк Продаж."); yield break; }
                 if (executionResult == null) { _log.LogWarning("Query.Execute null для Строк Продаж."); yield break; }
@@ -505,7 +505,7 @@ namespace OneCSqlEtl
             try
             {
                 q = _v8Application.NewObject("Query");
-                if (q == null) { _log.LogError("Не удалось создать объект Query для Строк Платежей."); yield break; }
+                if (q == null) { _log.LogError("Не удалось создать объект Query для Строк Платежей (_v8Application.NewObject(\"Query\") вернул null)."); yield break; }
                 try { q.Text = query; } catch (COMException ex) { _log.LogError(ex, "COMException текст запроса Строк Платежей."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка текст запроса Строк Платежей."); yield break; }
                 try { executionResult = q.Execute(); } catch (COMException ex) { _log.LogError(ex, "COMException запрос Строк Платежей."); yield break; } catch (Exception ex) { _log.LogError(ex, "Ошибка запрос Строк Платежей."); yield break; }
                 if (executionResult == null) { _log.LogWarning("Query.Execute null для Строк Платежей."); yield break; }


### PR DESCRIPTION
This commit updates the error logging in several Get...Internal methods within the OneCAccessor.cs file.

Previously, if the `_v8Application.NewObject(\"Query\")` call returned null, a generic error message was logged. This change makes the error message more specific by explicitly stating that
`_v8Application.NewObject(\"Query\")` returned null and for which entity type the query object creation failed.

Affected methods:
- GetOrganizationsInternal
- GetCustomersInternal
- GetProductsInternal
- GetContractsInternal
- GetSaleRowsInternal
- GetPaymentRowsInternal