### PR TITLE
Fix logging in dynamic value helper

### DIFF
--- a/OneCSqlEtl/OneCAccessor.cs
+++ b/OneCSqlEtl/OneCAccessor.cs
@@ -278,7 +278,15 @@ namespace OneCSqlEtl
             catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException rbEx)
             { logger.LogWarning(rbEx, "[GetSafeDynamicValue] RuntimeBinderException: Property '{Property}' not found or type mismatch for {Context}.", propertyName, contextMessage); return null; }
             catch (Exception ex)
-            { logger.LogWarning(ex, "[GetSafeDynamicValue] Exception converting/accessing property '{Property}' for {Context}. Value was: {PropValue}", propertyName, contextMessage, (object?)comObject[propertyName]?.ToString() ?? "null"); return null; } // Cast for logger
+            {
+                // Avoid accessing the dynamic property again here as it may
+                // throw the same exception that triggered this catch block.
+                logger.LogWarning(ex,
+                    "[GetSafeDynamicValue] Exception converting/accessing property '{Property}' for {Context}.",
+                    propertyName,
+                    contextMessage);
+                return null;
+            }
         }
 
         public IEnumerable<Customer1C> GetCustomers()


### PR DESCRIPTION
## Summary
- avoid accessing COM dynamic property again in `GetSafeDynamicValue`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f76daebec8322b7422ee6be741e39